### PR TITLE
Thesis #1: Cache regex escaping for delimiter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,13 @@ function escapeText(str: string) {
 /**
  * Escape a regular expression string.
  */
+const escapeCache = new Map<string, string>();
 function escape(str: string) {
-  return str.replace(/[.+*?^${}()[\]|/\\]/g, "\\$&");
+  let cached = escapeCache.get(str);
+  if (cached !== undefined) return cached;
+  const result = str.replace(/[.+*?^${}()[\]|/\\]/g, "\\$&");
+  escapeCache.set(str, result);
+  return result;
 }
 
 /**


### PR DESCRIPTION
References #1

Self-reported metric: 1457647.8300
Baseline: 1433213.8600
Summary: Added memoization cache for escape() function to avoid repeated regex operations on same delimiter input